### PR TITLE
fix: map api slugs to frontend slugs in pillar sitemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "2.31.5",
+  "version": "2.31.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/features/pillar/server/data/fetch-pillar-sitemap-slugs.ts
+++ b/src/features/pillar/server/data/fetch-pillar-sitemap-slugs.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 
+import { getFrontendSlug } from '@/features/pillar/constants';
 import { pillarSitemapSlugsDto } from '@/features/pillar/server/dtos/pillar-sitemap-slugs.dto';
 import { clientEnv } from '@/lib/env/client';
 
@@ -17,11 +18,16 @@ export const fetchPillarSitemapSlugs = async () => {
   const parsed = pillarSitemapSlugsDto.safeParse(json);
   if (!parsed.success) throw new Error('Failed to parse pillar sitemap slugs');
 
-  return parsed.data.data.filter((item) => {
-    const isSafe = item.slug.length <= LIMIT_LENGTH;
-    if (!isSafe) {
-      console.warn(`[fetchPillarSitemapSlugs] Slug too long: ${item.slug}`);
-    }
-    return isSafe;
-  });
+  return parsed.data.data
+    .filter((item) => {
+      const isSafe = item.slug.length <= LIMIT_LENGTH;
+      if (!isSafe) {
+        console.warn(`[fetchPillarSitemapSlugs] Slug too long: ${item.slug}`);
+      }
+      return isSafe;
+    })
+    .map((item) => ({
+      slug: getFrontendSlug(item.slug),
+      lastModified: item.lastModified,
+    }));
 };


### PR DESCRIPTION
## Summary
- Transform API slugs to frontend slugs via `getFrontendSlug` in the pillar sitemap fetcher so the emitted URLs match actual pillar routes.

## Test plan
- [x] Hit the pillar sitemap route and confirm `<loc>` entries use frontend slugs (e.g., `urgently-hiring` instead of `b-expertJobs`).
- [x] Spot-check a few transformed slugs resolve to valid pillar pages.