### PR TITLE
fix(auth): default login back link to public home

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "2.32.0",
+  "version": "2.32.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/features/auth/components/login-content.tsx
+++ b/src/features/auth/components/login-content.tsx
@@ -11,7 +11,8 @@ import { useLoginAuth } from './use-login-auth';
 import { useLoginContent } from './use-login-content';
 
 export const LoginContent = () => {
-  const { isNavigating, redirectTo, handleBack } = useLoginContent();
+  const { isNavigating, redirectTo, isBackToHome, handleBack } =
+    useLoginContent();
   const { login, isLoading } = useLoginAuth(redirectTo);
 
   if (isLoading) {
@@ -74,7 +75,7 @@ export const LoginContent = () => {
             'disabled:pointer-events-none disabled:opacity-50',
           )}
         >
-          Back to {redirectTo === '/' ? 'jobs' : 'previous page'}
+          Back to {isBackToHome ? 'jobs' : 'previous page'}
         </button>
       </div>
     </div>

--- a/src/features/auth/components/use-login-content.ts
+++ b/src/features/auth/components/use-login-content.ts
@@ -10,17 +10,21 @@ export const useLoginContent = () => {
   const searchParams = useSearchParams();
   const [isNavigating, startTransition] = useTransition();
 
-  const redirectTo = searchParams.get('redirect') ?? '/profile/jobs';
+  const redirectParam = searchParams.get('redirect');
+  const redirectTo = redirectParam ?? '/profile/jobs';
+  const backTo = redirectParam ?? '/';
+  const isBackToHome = backTo === '/';
 
   const handleBack = () => {
     startTransition(() => {
-      router.push(redirectTo);
+      router.push(backTo);
     });
   };
 
   return {
     isNavigating,
     redirectTo,
+    isBackToHome,
     handleBack,
   };
 };


### PR DESCRIPTION
## Summary

The login page's Back button sent users to `/profile/jobs`, an authenticated route guarded by `AuthGuard`. An unauthenticated visitor who clicked it was redirected straight back to `/login`, a dead-end loop. The Back destination now falls back to the public home (`/`) while the post-login redirect keeps its own `/profile/jobs` default, so a single overloaded value no longer serves two conflicting purposes.

## Changes

- Split `redirectTo` in `useLoginContent` into `redirectTo` (post-login target, still `/profile/jobs`) and `backTo` (Back button target, defaults to public home `/`); both still honor an explicit `?redirect=` query param.
- Expose an `isBackToHome` flag from the hook and drive the Back label from it, instead of comparing the route literal inside the component, so the label copy and navigation target cannot drift apart.
- Bump version to 2.32.1.

## Tests

No automated tests added or modified: there is no existing test suite for the auth login components, and this is a routing-default change. Verified oxlint passes with 0 warnings and 0 errors on both modified files.
