### PR TITLE
fix: socials hydration mismatch, hero CTA layout shift, logo sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "2.32.1",
+  "version": "2.32.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/hero-jobs-for-you-button.lazy.tsx
+++ b/src/components/hero-jobs-for-you-button.lazy.tsx
@@ -2,9 +2,7 @@
 
 import dynamic from 'next/dynamic';
 
-const SKELETON = (
-  <div className='h-10 w-36 animate-pulse rounded-lg bg-muted' />
-);
+import { HeroJobsForYouButtonSkeleton } from './hero-jobs-for-you-button.skeleton';
 
 export const HeroJobsForYouButton = dynamic(
   () =>
@@ -13,6 +11,6 @@ export const HeroJobsForYouButton = dynamic(
     ),
   {
     ssr: false,
-    loading: () => SKELETON,
+    loading: () => <HeroJobsForYouButtonSkeleton />,
   },
 );

--- a/src/components/hero-jobs-for-you-button.lazy.tsx
+++ b/src/components/hero-jobs-for-you-button.lazy.tsx
@@ -4,13 +4,38 @@ import dynamic from 'next/dynamic';
 
 import { HeroJobsForYouButtonSkeleton } from './hero-jobs-for-you-button.skeleton';
 
-export const HeroJobsForYouButton = dynamic(
+interface Props {
+  variant?: 'primary' | 'secondary';
+}
+
+// next/dynamic's `loading` can't receive props, so the chunk-load fallback can't
+// know the variant. Use one wrapper per variant (both resolve to the same chunk)
+// so the loading skeleton always matches the resolved button — no layout shift.
+const PrimaryButton = dynamic(
   () =>
     import('./hero-jobs-for-you-button').then(
       (mod) => mod.HeroJobsForYouButton,
     ),
   {
     ssr: false,
-    loading: () => <HeroJobsForYouButtonSkeleton />,
+    loading: () => <HeroJobsForYouButtonSkeleton variant='primary' />,
   },
 );
+
+const SecondaryButton = dynamic(
+  () =>
+    import('./hero-jobs-for-you-button').then(
+      (mod) => mod.HeroJobsForYouButton,
+    ),
+  {
+    ssr: false,
+    loading: () => <HeroJobsForYouButtonSkeleton variant='secondary' />,
+  },
+);
+
+export const HeroJobsForYouButton = ({ variant = 'secondary' }: Props) =>
+  variant === 'primary' ? (
+    <PrimaryButton variant='primary' />
+  ) : (
+    <SecondaryButton variant='secondary' />
+  );

--- a/src/components/hero-jobs-for-you-button.skeleton.tsx
+++ b/src/components/hero-jobs-for-you-button.skeleton.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@/components/ui/button';
+import { PrimaryCTA } from '@/components/primary-cta';
+
+interface Props {
+  variant?: 'primary' | 'secondary';
+}
+
+// Renders the resolved button's exact box (same component, size, and label) as a
+// muted, non-interactive placeholder. Matching the label width means there is no
+// layout shift when the real CTA resolves.
+export const HeroJobsForYouButtonSkeleton = ({
+  variant = 'secondary',
+}: Props) => {
+  if (variant === 'primary') {
+    return (
+      <PrimaryCTA
+        aria-hidden
+        className='pointer-events-none animate-pulse px-6 text-base text-transparent'
+      >
+        Jobs For You
+      </PrimaryCTA>
+    );
+  }
+
+  return (
+    <Button
+      aria-hidden
+      tabIndex={-1}
+      size='lg'
+      variant='secondary'
+      className='pointer-events-none animate-pulse bg-accent text-base text-transparent'
+    >
+      Jobs For You
+    </Button>
+  );
+};

--- a/src/components/hero-jobs-for-you-button.tsx
+++ b/src/components/hero-jobs-for-you-button.tsx
@@ -6,9 +6,8 @@ import { useEligibility } from '@/hooks/use-eligibility';
 import { GA_EVENT, trackEvent } from '@/lib/analytics';
 import { Button } from '@/components/ui/button';
 import { PrimaryCTA } from '@/components/primary-cta';
-import { Skeleton } from '@/components/ui/skeleton';
 
-const SKELETON = <Skeleton className='h-10 w-36 rounded-lg' />;
+import { HeroJobsForYouButtonSkeleton } from './hero-jobs-for-you-button.skeleton';
 
 const handleClick = () => {
   trackEvent(GA_EVENT.HERO_CTA_CLICKED, { source: 'hero_jobs_for_you' });
@@ -21,7 +20,7 @@ interface Props {
 export const HeroJobsForYouButton = ({ variant = 'secondary' }: Props) => {
   const { isAuthenticated, isLoading } = useEligibility();
 
-  if (isLoading) return SKELETON;
+  if (isLoading) return <HeroJobsForYouButtonSkeleton variant={variant} />;
 
   const href = isAuthenticated ? '/profile/jobs' : '/login';
 

--- a/src/components/jobstash-logo.tsx
+++ b/src/components/jobstash-logo.tsx
@@ -14,6 +14,7 @@ export const JobstashLogo = ({ className }: JobstashLogoProps) => {
         fill
         priority
         quality={50}
+        sizes='64px'
         src='/jobstash-logo.png'
         alt='JobStash Logo'
         style={{ objectFit: 'contain' }}

--- a/src/components/socials-aside-content.tsx
+++ b/src/components/socials-aside-content.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+
+import { MessageSquareMoreIcon } from 'lucide-react';
+import { TelegramIcon } from '@/components/svg/telegram-icon';
+import { TwitterIcon } from '@/components/svg/twitter-icon';
+import { FarcasterIcon } from '@/components/svg/farcaster-icon';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { Button } from '@/components/ui/button';
+
+import { SOCIALS, SOCIALS_CONTAINER } from './socials-aside.shared';
+
+const ICONS = {
+  Telegram: <TelegramIcon />,
+  X: <TwitterIcon />,
+  Farcaster: <FarcasterIcon />,
+  Community: <MessageSquareMoreIcon />,
+} as const;
+
+const SocialsAsideContent = () => (
+  <div className={SOCIALS_CONTAINER}>
+    {SOCIALS.map(({ label, href }) => (
+      <div key={label} className='flex items-center gap-2'>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant='secondary' className='h-9 w-12' asChild>
+              <Link
+                href={href}
+                target='_blank'
+                rel='noopener noreferrer'
+                aria-label={label}
+              >
+                {ICONS[label]}
+              </Link>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{label}</TooltipContent>
+        </Tooltip>
+      </div>
+    ))}
+  </div>
+);
+
+export default SocialsAsideContent;

--- a/src/components/socials-aside.shared.ts
+++ b/src/components/socials-aside.shared.ts
@@ -1,0 +1,9 @@
+export const SOCIALS_CONTAINER =
+  'flex w-full justify-between rounded-2xl border border-neutral-800/50 bg-sidebar p-4';
+
+export const SOCIALS = [
+  { label: 'Telegram', href: 'https://telegram.me/jobstash' },
+  { label: 'X', href: 'https://x.com/jobstash_xyz' },
+  { label: 'Farcaster', href: 'https://farcaster.xyz/~/channel/jobstash' },
+  { label: 'Community', href: 'https://telegram.me/jobstashxyz' },
+] as const;

--- a/src/components/socials-aside.test.tsx
+++ b/src/components/socials-aside.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { SocialsAside } from './socials-aside';
+import SocialsAsideContent from './socials-aside-content';
 
 afterEach(() => {
   cleanup();
@@ -24,9 +24,9 @@ vi.mock('next/link', () => ({
   ),
 }));
 
-describe('SocialsAside', () => {
+describe('SocialsAsideContent', () => {
   it('renders all 4 social links', () => {
-    render(<SocialsAside />);
+    render(<SocialsAsideContent />);
 
     expect(screen.getByRole('link', { name: 'Telegram' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'X' })).toBeInTheDocument();
@@ -35,7 +35,7 @@ describe('SocialsAside', () => {
   });
 
   it('has correct hrefs', () => {
-    render(<SocialsAside />);
+    render(<SocialsAsideContent />);
 
     expect(screen.getByRole('link', { name: 'Telegram' })).toHaveAttribute(
       'href',
@@ -56,7 +56,7 @@ describe('SocialsAside', () => {
   });
 
   it('opens links in new tab', () => {
-    render(<SocialsAside />);
+    render(<SocialsAsideContent />);
 
     const links = screen.getAllByRole('link');
     links.forEach((link) => {

--- a/src/components/socials-aside.tsx
+++ b/src/components/socials-aside.tsx
@@ -1,64 +1,27 @@
-import Link from 'next/link';
+'use client';
 
-import { MessageSquareMoreIcon } from 'lucide-react';
-import { TelegramIcon } from '@/components/svg/telegram-icon';
-import { TwitterIcon } from '@/components/svg/twitter-icon';
-import { FarcasterIcon } from '@/components/svg/farcaster-icon';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
-import { Button } from '@/components/ui/button';
+import dynamic from 'next/dynamic';
 
-const SOCIALS = [
-  {
-    label: 'Telegram',
-    icon: <TelegramIcon />,
-    href: 'https://telegram.me/jobstash',
-  },
-  {
-    label: 'X',
-    icon: <TwitterIcon />,
-    href: 'https://x.com/jobstash_xyz',
-  },
-  {
-    label: 'Farcaster',
-    icon: <FarcasterIcon />,
-    href: 'https://farcaster.xyz/~/channel/jobstash',
-  },
-  {
-    label: 'Community',
-    icon: <MessageSquareMoreIcon />,
-    href: 'https://telegram.me/jobstashxyz',
-  },
-];
+import { Skeleton } from '@/components/ui/skeleton';
 
-export const SocialsAside = () => {
-  return (
-    <div className='flex w-full justify-between rounded-2xl border border-neutral-800/50 bg-sidebar p-4'>
-      {SOCIALS.map(({ label, icon, href }) => (
-        <div key={label} className='flex items-center gap-2'>
-          <TooltipProvider delayDuration={0}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant='secondary' className='h-9 w-12' asChild>
-                  <Link
-                    href={href}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    aria-label={label}
-                  >
-                    {icon}
-                  </Link>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>{label}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div>
-      ))}
-    </div>
-  );
-};
+import { SOCIALS, SOCIALS_CONTAINER } from './socials-aside.shared';
+
+const SocialsAsideSkeleton = () => (
+  <div className={SOCIALS_CONTAINER}>
+    {SOCIALS.map(({ label }) => (
+      <div key={label} className='flex items-center gap-2'>
+        <Skeleton className='h-9 w-12' />
+      </div>
+    ))}
+  </div>
+);
+
+// The Radix Tooltip subtree fails to render server-side when placed in the
+// non-suspended page shell (a Next 16 streaming-SSR quirk), causing hydration
+// mismatches. Render it client-only behind a same-size skeleton (no layout shift).
+const SocialsAsideContent = dynamic(() => import('./socials-aside-content'), {
+  ssr: false,
+  loading: () => <SocialsAsideSkeleton />,
+});
+
+export const SocialsAside = () => <SocialsAsideContent />;


### PR DESCRIPTION
## Summary

Fixes a home-page hydration mismatch where the sidebar social links rendered empty on the server but complete on the client. The cause is a Next 16 streaming-SSR behavior: a Radix Tooltip placed in the non-suspended page shell renders nothing server-side, so the client's full markup did not match. Two related home-page issues found while fixing it are included: a hero CTA layout shift as the "Jobs For You" button loads, and a missing `sizes` prop on the logo image.

## Changes

- Render `SocialsAside` client-side via `next/dynamic` (`ssr: false`) behind a same-size skeleton, so the Radix Tooltip subtree never renders during SSR and the server and client outputs match (`socials-aside.tsx`, `socials-aside-content.tsx`, `socials-aside.shared.ts`).
- Replace the hero "Jobs For You" fixed-size loading placeholders (`h-10 w-36`) with a button-shaped skeleton that reuses the real button's size and label, removing the CTA layout shift (`hero-jobs-for-you-button.tsx`, `hero-jobs-for-you-button.skeleton.tsx`).
- Make the lazy chunk-load fallback variant-aware so the primary "Jobs For You" CTA on `/urgently-hiring` also matches its skeleton during the JS chunk load (`hero-jobs-for-you-button.lazy.tsx`).
- Add `sizes='64px'` to the logo `Image` (which uses `fill`) to clear the next/image performance warning and stop it generating a 3840px-wide srcset for the 40-64px logo (`jobstash-logo.tsx`).
- Bump version to 2.32.2 (`package.json`).

## Tests

Updated `socials-aside.test.tsx` (3 cases: links render, correct hrefs, open in new tab) to render `SocialsAsideContent` directly, since `SocialsAside` now lazy-loads it and renders only a skeleton synchronously; the full suite passes (88 tests). The SSR and render-timing behaviors were verified manually in a headless browser against the rebased branch: no hydration error in the console, CLS = 0 on both the home and `/urgently-hiring` heroes, and the logo `sizes` warning gone. `prettier`, `oxlint`, and `tsc --noEmit` pass on all changed files.
