### PR TITLE
fix: pin pnpm to 10.28.0 to unblock coolify deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -73,8 +71,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -103,8 +99,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@
 FROM node:22-alpine AS deps
 WORKDIR /app
 
-# Enable corepack for pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Enable corepack and pin pnpm to match package.json's "packageManager".
+# Do NOT use pnpm@latest: a release newer than 10.28.0 made ignored build
+# scripts a fatal error (ERR_PNPM_IGNORED_BUILDS), which broke this build.
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
 
 # Copy package files
 COPY package.json pnpm-lock.yaml ./
@@ -15,8 +17,8 @@ RUN pnpm install --frozen-lockfile
 FROM node:22-alpine AS builder
 WORKDIR /app
 
-# Enable corepack for pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Enable corepack and pin pnpm (must match the deps stage and package.json)
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
 
 # Build-time environment variables (Coolify passes these as --build-arg)
 ARG NEXT_PUBLIC_MW_URL

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "webapp",
   "version": "2.32.2",
   "private": true,
+  "packageManager": "pnpm@10.28.0",
   "scripts": {
     "dev": "next dev",
     "prebuild": "pnpm format && pnpm lint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "2.32.2",
+  "version": "2.32.3",
   "private": true,
   "packageManager": "pnpm@10.28.0",
   "scripts": {


### PR DESCRIPTION
## Summary

The Coolify deploy broke because the Dockerfile installed pnpm via `corepack prepare pnpm@latest`, which now resolves to pnpm 11.x. pnpm releases newer than 10.28.0 treat ignored dependency build scripts as a fatal `ERR_PNPM_IGNORED_BUILDS` error instead of a warning, so `pnpm install --frozen-lockfile` exits 1 during the Docker build. Pinning pnpm to 10.28.0 restores deterministic, known-good installs.

## Changes

- Pin pnpm to `10.28.0` in both Dockerfile stages (`deps` and `builder`), replacing `corepack prepare pnpm@latest`, with a comment so it is not reverted to `@latest`.
- Add `"packageManager": "pnpm@10.28.0"` to `package.json` so local, CI, and Docker all resolve the same pnpm.
- Bump version `2.32.2` to `2.32.3`.

## Tests

Build-tooling change, no test modifications needed. Reproduced the failure locally against the exact `package.json` + `pnpm-lock.yaml`: pnpm 10.28.0 installs and exits 0 (warning only), while a newer pnpm exits 1 with `ERR_PNPM_IGNORED_BUILDS`. Full `docker build` not run (local Docker daemon offline); the Coolify build will be the end-to-end confirmation.