### PR TITLE
feat: mobile/tablet filter drawer below the lg breakpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "private": true,
   "packageManager": "pnpm@10.28.0",
   "scripts": {

--- a/src/app/(main)/(home)/page.tsx
+++ b/src/app/(main)/(home)/page.tsx
@@ -2,7 +2,10 @@ import { Suspense } from 'react';
 import type { Metadata } from 'next';
 
 import { SocialsAside } from '@/components/socials-aside';
-import { FiltersAside } from '@/features/filters/components/filters-aside';
+import {
+  FiltersAside,
+  FiltersDrawer,
+} from '@/features/filters/components/filters-aside';
 import { JobList } from '@/features/jobs/components/job-list/job-list';
 import { JobListBoundary } from '@/features/jobs/components/job-list/job-list.error';
 import { JobListSkeleton } from '@/features/jobs/components/job-list/job-list.skeleton';
@@ -74,6 +77,9 @@ const HomePage = async ({ searchParams }: Props) => {
         <SocialsAside />
       </aside>
       <section className='min-w-0 grow'>
+        <div className='mb-4 lg:hidden'>
+          <FiltersDrawer />
+        </div>
         <Suspense fallback={<JobListSkeleton />}>
           <JobListBoundary>
             <JobList

--- a/src/app/(main)/[slug]/page.tsx
+++ b/src/app/(main)/[slug]/page.tsx
@@ -1,7 +1,10 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
-import { FiltersAside } from '@/features/filters/components/filters-aside';
+import {
+  FiltersAside,
+  FiltersDrawer,
+} from '@/features/filters/components/filters-aside';
 import { OrgInfoCard } from '@/features/jobs/components/job-details/org-info-card';
 import {
   OrgAboutSection,
@@ -115,6 +118,9 @@ const PillarPage = async ({ params }: Props) => {
           <SuggestedPillars items={suggestedPillars} />
         </aside>
         <section className='min-w-0 grow'>
+          <div className='mb-4 lg:hidden'>
+            <FiltersDrawer pillarMode pillarContext={pillarContext} />
+          </div>
           <PillarJobList
             slug={slug}
             pillarContext={pillarContext}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import * as React from 'react';
+import * as SheetPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils/index';
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot='sheet' {...props} />;
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot='sheet-trigger' {...props} />;
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot='sheet-close' {...props} />;
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot='sheet-portal' {...props} />;
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot='sheet-overlay'
+      className={cn(
+        'fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetContent({
+  className,
+  children,
+  side = 'left',
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: 'top' | 'right' | 'bottom' | 'left';
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot='sheet-content'
+        className={cn(
+          'fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500',
+          side === 'left' &&
+            'inset-y-0 left-0 h-full w-3/4 max-w-sm border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
+          side === 'right' &&
+            'inset-y-0 right-0 h-full w-3/4 max-w-sm border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right',
+          side === 'top' &&
+            'inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+          side === 'bottom' &&
+            'inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close className='absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary'>
+          <XIcon className='size-4' />
+          <span className='sr-only'>Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot='sheet-header'
+      className={cn('flex flex-col gap-1.5 p-4', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot='sheet-footer'
+      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot='sheet-title'
+      className={cn('font-semibold text-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot='sheet-description'
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+};

--- a/src/features/filters/components/filters-aside/filters-drawer.client.tsx
+++ b/src/features/filters/components/filters-aside/filters-drawer.client.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState } from 'react';
+import { FunnelIcon } from 'lucide-react';
+
+import type { PillarFilterContext } from '@/features/pillar/schemas';
+import type { FilterConfigSchema } from '@/features/filters/schemas';
+import { useActiveFilters } from '@/features/filters/hooks';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
+
+import { FiltersAsideClient } from './filters-aside.client';
+
+interface Props {
+  configs: FilterConfigSchema[];
+  pillarContext?: PillarFilterContext | null;
+  pillarMode?: boolean;
+}
+
+export const FiltersDrawerClient = ({
+  configs,
+  pillarContext,
+  pillarMode,
+}: Props) => {
+  const [open, setOpen] = useState(false);
+
+  // Outside the pillar provider this counts URL-active filters (home). On
+  // pillar pages the URL is empty, so count the pillar's implied criteria.
+  const urlActiveCount = useActiveFilters(configs).length;
+  const activeCount = pillarMode ? 1 + (pillarContext ? 1 : 0) : urlActiveCount;
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button variant='secondary' size='sm' className='gap-2'>
+          <FunnelIcon className='size-3.5' />
+          Filters
+          {activeCount > 0 && (
+            <Badge variant='default' className='px-1.5 text-[10px]'>
+              {activeCount}
+            </Badge>
+          )}
+        </Button>
+      </SheetTrigger>
+      <SheetContent
+        side='left'
+        className='w-80 max-w-[85vw]'
+        // Don't auto-focus the first chip — it pops its tooltip on open
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <SheetHeader className='border-b border-border/50'>
+          <SheetTitle>Filters</SheetTitle>
+        </SheetHeader>
+        <div className='flex-1 overflow-y-auto px-4 pb-6'>
+          <div className='flex flex-col gap-2 [&_button]:w-fit'>
+            <FiltersAsideClient
+              configs={configs}
+              pillarContext={pillarContext}
+              pillarMode={pillarMode}
+            />
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/src/features/filters/components/filters-aside/filters-drawer.tsx
+++ b/src/features/filters/components/filters-aside/filters-drawer.tsx
@@ -1,0 +1,38 @@
+import { Suspense } from 'react';
+
+import type { PillarFilterContext } from '@/features/pillar/schemas';
+import { fetchFilterConfigs } from '@/features/filters/server/data';
+
+import { FiltersAsideBoundary } from './filters-aside.error';
+import { FiltersDrawerClient } from './filters-drawer.client';
+
+interface FiltersDrawerProps {
+  pillarContext?: PillarFilterContext | null;
+  pillarMode?: boolean;
+}
+
+// Filter access for viewports below lg, where the sidebar is hidden: a
+// "Filters" button opening the same filter UI in a slide-in sheet. Render
+// inside an `lg:hidden` wrapper. The configs fetch is request-deduped with
+// the sidebar's.
+const FiltersDrawerRSC = async ({
+  pillarContext,
+  pillarMode,
+}: FiltersDrawerProps) => {
+  const filterConfigs = await fetchFilterConfigs();
+  return (
+    <FiltersDrawerClient
+      configs={filterConfigs}
+      pillarContext={pillarContext}
+      pillarMode={pillarMode}
+    />
+  );
+};
+
+export const FiltersDrawer = (props: FiltersDrawerProps) => (
+  <Suspense fallback={null}>
+    <FiltersAsideBoundary fallback={null}>
+      <FiltersDrawerRSC {...props} />
+    </FiltersAsideBoundary>
+  </Suspense>
+);

--- a/src/features/filters/components/filters-aside/index.ts
+++ b/src/features/filters/components/filters-aside/index.ts
@@ -1,1 +1,2 @@
 export { FiltersAside } from './filters-aside';
+export { FiltersDrawer } from './filters-drawer';


### PR DESCRIPTION
Below 1024px CSS width the filter sidebar is `hidden lg:flex` and there was **no filter access at all** — on the home page or pillar pages. This is why the pillar recency chips ("This Month") appeared missing on scaled/narrow windows.

## What's new
- A **"Filters" button** (with an active-filter count badge) above the job list on sub-`lg` viewports, on both the home page and pillar pages
- Opens the complete filter UI in a **left slide-in sheet**: active chips, suggested filters, More Filters — including the pillar mock chips and their transition to real filter mode
- New shadcn-style `Sheet` component built on the already-installed Radix dialog primitive
- `FiltersDrawer` RSC reuses `fetchFilterConfigs` (request-deduped with the sidebar fetch) and renders `FiltersAsideClient` wholesale — zero duplication of filter logic

## Verified at 900px viewport
- `/lt-remote`: "Filters 2" button → drawer shows "This Month" + "Work Mode (1)" pre-set chips
- Removing "This Month" from the drawer navigates to `/?locations=remote` (real filter mode)
- Home with `?locations=remote`: badge shows "Filters 1"
- Desktop ≥1024px unchanged (drawer wrapper is `lg:hidden`)
- tsc clean, 126 tests green, production build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2r9SoF8wmxr5FHzrmX1bi