### PR TITLE
fix: job detail sidebar grows to natural height, no inner scrollbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "private": true,
   "packageManager": "pnpm@10.28.0",
   "scripts": {

--- a/src/features/jobs/components/job-details/job-details-page.tsx
+++ b/src/features/jobs/components/job-details/job-details-page.tsx
@@ -32,7 +32,10 @@ export const JobDetailsPage = ({ job }: JobDetailsPageProps) => {
             </div>
           </article>
 
-          <aside className='sticky top-20 hidden max-h-[calc(100vh-5rem)] w-80 shrink-0 flex-col gap-4 self-start overflow-y-auto lg:top-24 lg:flex lg:max-h-[calc(100vh-6rem)]'>
+          {/* Normal flow, natural height — the enriched org card makes this
+              column taller than the viewport, and an inner scrollbar (sticky
+              + max-h + overflow) reads as broken next to the article */}
+          <aside className='hidden w-80 shrink-0 flex-col gap-4 self-start lg:flex'>
             <JobDetailsSidebar job={job} isExpertJob={isExpertJob} />
           </aside>
         </div>


### PR DESCRIPTION
The right column on job detail pages was sticky and viewport-capped (`max-h` + `overflow-y-auto`); with the enriched org card its content exceeds the viewport, so the column showed its own scrollbar next to the article.

It now sits in normal page flow at its full block height — same feel as the pillar-page columns. Verified at 1440px with a heavy sidebar (Morpho: projects, funding, investors, similar jobs — 1050px column): no inner scrollbar, page scrolls as one unit. Sub-`lg` layouts unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2r9SoF8wmxr5FHzrmX1bi