### PR TITLE
fix: filter block and left columns grow to natural height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "2.35.1",
+  "version": "2.35.2",
   "private": true,
   "packageManager": "pnpm@10.28.0",
   "scripts": {

--- a/src/app/(main)/(home)/page.tsx
+++ b/src/app/(main)/(home)/page.tsx
@@ -71,7 +71,7 @@ const HomePage = async ({ searchParams }: Props) => {
 
   return (
     <div className='flex gap-4'>
-      <aside className='sticky top-20 hidden max-h-[calc(100vh-5rem)] w-68 shrink-0 flex-col gap-4 self-start overflow-y-auto lg:top-24 lg:flex lg:max-h-[calc(100vh-6rem)]'>
+      <aside className='hidden w-68 shrink-0 flex-col gap-4 self-start lg:flex'>
         <FiltersAside />
         <SuggestedPillars items={suggestedPillarLinks} />
         <SocialsAside />

--- a/src/app/(main)/[slug]/page.tsx
+++ b/src/app/(main)/[slug]/page.tsx
@@ -112,7 +112,9 @@ const PillarPage = async ({ params }: Props) => {
         <OrgAboutSection name={org.name} description={orgDescription} />
       )}
       <div id='jobs' className='flex scroll-mt-20 gap-4 pt-4 lg:scroll-mt-24'>
-        <aside className='sticky top-20 hidden max-h-[calc(100vh-5rem)] w-68 shrink-0 flex-col gap-4 self-start overflow-y-auto lg:top-24 lg:flex lg:max-h-[calc(100vh-6rem)]'>
+        {/* Normal flow, natural height — a viewport-capped column gives the
+            filter block its own scrollbar once the org card is present */}
+        <aside className='hidden w-68 shrink-0 flex-col gap-4 self-start lg:flex'>
           {org && <OrgInfoCard organization={org} hideJobsButton />}
           <FiltersAside pillarMode pillarContext={pillarContext} />
           <SuggestedPillars items={suggestedPillars} />

--- a/src/features/filters/components/filters-aside/filters-aside.layout.tsx
+++ b/src/features/filters/components/filters-aside/filters-aside.layout.tsx
@@ -2,7 +2,7 @@ export const FiltersAsideLayout = ({
   children,
 }: React.PropsWithChildren): React.ReactElement => {
   return (
-    <div className='flex w-full flex-col gap-4 overflow-y-auto rounded-2xl border border-neutral-800/50 bg-sidebar p-4'>
+    <div className='flex w-full flex-col gap-4 rounded-2xl border border-neutral-800/50 bg-sidebar p-4'>
       <span className='font-medium'>Filters</span>
       {children}
     </div>


### PR DESCRIPTION
Follow-up to #132, same class of issue on the other pages: the Filters card had its own `overflow-y-auto`, and the pillar/home left columns were sticky and viewport-capped — so on org pillar pages (where the enriched org card fills the column) the filter block rendered an internal scrollbar.

Both layers are now in normal page flow at their full block height, consistent with the job-detail sidebar. The mobile filter drawer keeps its internal scroll (a sheet is viewport-bound by design).

Verified on the production build at 1440px:
- `/o-offchain-labs`: aside static/1011px natural height, filter card 353px, zero scrolling elements in the column
- Home: aside static, zero inner scrollers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2r9SoF8wmxr5FHzrmX1bi