### PR TITLE
fix: sitemap lastmod hygiene — omit bogus dates, dedupe job urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "2.35.2",
+  "version": "2.35.3",
   "private": true,
   "packageManager": "pnpm@10.28.0",
   "scripts": {

--- a/src/features/jobs/server/data/fetch-sitemap-jobs.test.ts
+++ b/src/features/jobs/server/data/fetch-sitemap-jobs.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/env/client', () => ({
+  clientEnv: {
+    MW_URL: 'https://mw.test',
+    FRONTEND_URL: 'https://fe.test',
+  },
+}));
+
+import { toSitemapEntries } from './fetch-sitemap-jobs';
+
+const job = (overrides: Record<string, unknown> = {}) => ({
+  shortUUID: 'abc123',
+  title: 'Product Manager',
+  organizationName: 'Harmony',
+  timestamp: Date.UTC(2026, 0, 15),
+  ...overrides,
+});
+
+describe('toSitemapEntries', () => {
+  it('keeps valid timestamps as lastModified', () => {
+    const [entry] = toSitemapEntries([job()]);
+    expect(entry.href).toBe('/product-manager-harmony/abc123');
+    expect(entry.lastModified).toEqual(new Date(Date.UTC(2026, 0, 15)));
+  });
+
+  it.each([
+    ['epoch 0', 0],
+    ['pre-2000 artifact', Date.UTC(1999, 11, 31)],
+    ['null', null],
+  ])('omits lastModified for %s instead of emitting a bogus date', (_l, ts) => {
+    const [entry] = toSitemapEntries([job({ timestamp: ts })]);
+    expect(entry.href).toBe('/product-manager-harmony/abc123');
+    expect(entry.lastModified).toBeUndefined();
+  });
+
+  it('dedupes identical urls, keeping the newest date', () => {
+    const entries = toSitemapEntries([
+      job({ timestamp: Date.UTC(2026, 0, 1) }),
+      job({ timestamp: Date.UTC(2026, 2, 1) }),
+      job({ timestamp: 0 }),
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].lastModified).toEqual(new Date(Date.UTC(2026, 2, 1)));
+  });
+
+  it('a dateless duplicate does not clobber a dated entry', () => {
+    const entries = toSitemapEntries([
+      job({ timestamp: 0 }),
+      job({ timestamp: Date.UTC(2026, 1, 1) }),
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].lastModified).toEqual(new Date(Date.UTC(2026, 1, 1)));
+  });
+});

--- a/src/features/jobs/server/data/fetch-sitemap-jobs.ts
+++ b/src/features/jobs/server/data/fetch-sitemap-jobs.ts
@@ -7,7 +7,39 @@ import {
 import { clientEnv } from '@/lib/env/client';
 import { slugify } from '@/lib/server/utils';
 
-export const fetchSitemapJobs = async () => {
+// lastmod sanity floor: anything before 2000-01-01 is a data artifact
+// (epoch-0 placeholders), not a real date. A wrong lastmod is worse than
+// none — Google stops trusting the sitemap's lastmod signals entirely.
+const MIN_VALID_TIMESTAMP = Date.UTC(2000, 0, 1);
+
+export interface SitemapJobEntry {
+  href: string;
+  lastModified?: Date;
+}
+
+export const toSitemapEntries = (jobs: SitemapJobDto[]): SitemapJobEntry[] => {
+  const byHref = new Map<string, SitemapJobEntry>();
+
+  for (const job of jobs) {
+    const href = createSitemapJobHref(job);
+    const isValidDate =
+      typeof job.timestamp === 'number' && job.timestamp >= MIN_VALID_TIMESTAMP;
+    const lastModified = isValidDate
+      ? new Date(job.timestamp as number)
+      : undefined;
+
+    const existing = byHref.get(href);
+    const keepNew =
+      !existing ||
+      (lastModified &&
+        (!existing.lastModified || lastModified > existing.lastModified));
+    if (keepNew) byHref.set(href, { href, lastModified });
+  }
+
+  return [...byHref.values()];
+};
+
+export const fetchSitemapJobs = async (): Promise<SitemapJobEntry[]> => {
   const url = `${clientEnv.MW_URL}/v2/search/sitemap/jobs`;
   const response = await fetch(url, {
     cache: 'force-cache',
@@ -19,10 +51,7 @@ export const fetchSitemapJobs = async () => {
   const parsed = sitemapJobsResponseDto.safeParse(json);
   if (!parsed.success) throw new Error('Failed to parse sitemap jobs');
 
-  return parsed.data.data.map((job) => ({
-    href: createSitemapJobHref(job),
-    lastModified: new Date(job.timestamp),
-  }));
+  return toSitemapEntries(parsed.data.data);
 };
 
 const createSitemapJobHref = (job: SitemapJobDto) => {

--- a/src/features/jobs/server/dtos/sitemap-job.dto.ts
+++ b/src/features/jobs/server/dtos/sitemap-job.dto.ts
@@ -6,7 +6,8 @@ export const sitemapJobDto = z.object({
   shortUUID: z.string(),
   title: z.string().nullable(),
   organizationName: z.string().nullable(),
-  timestamp: z.number(),
+  // null when MW has no usable date for the job
+  timestamp: z.number().nullable(),
 });
 export type SitemapJobDto = z.infer<typeof sitemapJobDto>;
 


### PR DESCRIPTION
Webapp side of jobstash/middleware#177 (epoch-0 lastmod dates in `/sitemaps/jobs-1`).

- Entries omit `<lastmod>` entirely when the timestamp is missing or predates 2000-01-01 — per Google's guidance, an absent lastmod is neutral but a provably wrong one gets the whole sitemap's lastmod signals discounted
- Duplicate URLs (same job reachable via multiple org paths — 149 URLs appeared up to 4×) collapse to one entry keeping the newest date
- DTO tolerates `timestamp: null` from the fixed middleware; works with the currently-deployed MW too (0 → treated as missing)

With the MW fix deployed, all entries carry a real date (true publish date when valid, ingestion date otherwise), so in practice nothing should hit the omission path — this is defense in depth.

132 tests green (6 new for the normalization), tsc clean, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2r9SoF8wmxr5FHzrmX1bi