### PR TITLE
Show hiring process on job details

### DIFF
--- a/src/features/jobs/components/job-details/job-details-content.tsx
+++ b/src/features/jobs/components/job-details/job-details-content.tsx
@@ -14,7 +14,13 @@ interface JobDetailsContentProps {
 }
 
 export const JobDetailsContent = ({ job, tags }: JobDetailsContentProps) => {
-  const { description, requirements, responsibilities, benefits } = job;
+  const {
+    description,
+    requirements,
+    responsibilities,
+    benefits,
+    hiringProcess,
+  } = job;
 
   const bulletSections = [
     { title: 'Requirements', items: requirements },
@@ -33,6 +39,13 @@ export const JobDetailsContent = ({ job, tags }: JobDetailsContentProps) => {
       {bulletSections.map(({ title, items }) => (
         <BulletSection key={title} title={title} items={items} />
       ))}
+
+      {hiringProcess && (
+        <DescriptionSection
+          title='Hiring Process'
+          description={hiringProcess}
+        />
+      )}
     </div>
   );
 };

--- a/src/features/jobs/schemas.ts
+++ b/src/features/jobs/schemas.ts
@@ -107,6 +107,7 @@ export const jobDetailsSchema = jobListItemSchema.extend({
   responsibilities: z.string().array(),
   benefits: z.string().array(),
   culture: nullableStringSchema,
+  hiringProcess: nullableStringSchema,
   similarJobs: similarJobSchema.array(),
 });
 export type JobDetailsSchema = z.infer<typeof jobDetailsSchema>;

--- a/src/features/jobs/server/dtos/dto-to-job-details.ts
+++ b/src/features/jobs/server/dtos/dto-to-job-details.ts
@@ -47,6 +47,7 @@ export const dtoToJobDetails = (
     responsibilities: dto.responsibilities ?? [],
     benefits: dto.benefits ?? [],
     culture: dto.culture,
+    hiringProcess: dto.hiringProcess ?? null,
     similarJobs,
   };
 };

--- a/src/features/jobs/server/dtos/job-details.dto.ts
+++ b/src/features/jobs/server/dtos/job-details.dto.ts
@@ -11,5 +11,6 @@ export const jobDetailsDto = jobListItemDto.extend({
   responsibilities: z.string().array().nullable(),
   benefits: z.string().array().nullable(),
   culture: nullableStringSchema,
+  hiringProcess: nullableStringSchema.optional(),
 });
 export type JobDetailsDto = z.infer<typeof jobDetailsDto>;


### PR DESCRIPTION
Renders a 'Hiring Process' section on the job detail page when the middleware payload carries a non-empty hiringProcess (nullable, tolerant of older middleware). Merge after the middleware deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)