### PR TITLE
fix: restore the job_apply GA event contract from the previous app

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,10 +10,17 @@ z.object({
   NEXT_PUBLIC_FRONTEND_URL: z.url(),
   NEXT_PUBLIC_MW_URL: z.url(),
   NEXT_PUBLIC_PRIVY_APP_ID: z.string().min(1),
+  // Strict shape: the id is interpolated into an inline <script> in the
+  // root layout, so reject anything that could break out of it
+  NEXT_PUBLIC_GA_MEASUREMENT_ID: z
+    .string()
+    .regex(/^G-[A-Z0-9]+$/)
+    .optional(),
 }).parse({
   NEXT_PUBLIC_FRONTEND_URL: process.env.NEXT_PUBLIC_FRONTEND_URL,
   NEXT_PUBLIC_MW_URL: process.env.NEXT_PUBLIC_MW_URL,
   NEXT_PUBLIC_PRIVY_APP_ID: process.env.NEXT_PUBLIC_PRIVY_APP_ID,
+  NEXT_PUBLIC_GA_MEASUREMENT_ID: process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID,
 });
 
 const nextConfig: NextConfig = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "2.35.3",
+  "version": "2.35.4",
   "private": true,
   "packageManager": "pnpm@10.28.0",
   "scripts": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -46,15 +46,17 @@ const RootLayout = ({ children }: Props) => (
     <body className='antialiased'>
       <RootProviders>{children}</RootProviders>
     </body>
+    {/* afterInteractive (not lazyOnload): job pages are SEO landing pages
+        and early Apply clicks must not be lost while GA idles */}
     {clientEnv.GA_MEASUREMENT_ID && (
       <>
         <Script
           id='_next-ga-init'
-          strategy='lazyOnload'
+          strategy='afterInteractive'
           dangerouslySetInnerHTML={{
             __html: `
               window.dataLayer=window.dataLayer||[];
-              function gtag(){dataLayer.push(arguments);}
+              window.gtag=window.gtag||function(){dataLayer.push(arguments);};
               gtag('js',new Date());
               gtag('config','${clientEnv.GA_MEASUREMENT_ID}');
             `,
@@ -63,7 +65,7 @@ const RootLayout = ({ children }: Props) => (
         <Script
           id='_next-ga'
           src={`https://www.googletagmanager.com/gtag/js?id=${clientEnv.GA_MEASUREMENT_ID}`}
-          strategy='lazyOnload'
+          strategy='afterInteractive'
         />
       </>
     )}

--- a/src/features/jobs/components/job-details/apply-button.tsx
+++ b/src/features/jobs/components/job-details/apply-button.tsx
@@ -12,6 +12,7 @@ import {
   type MissingItem,
 } from '@/features/jobs/apply-constants';
 import { GA_EVENT, trackEvent } from '@/lib/analytics';
+import { useEligibility } from '@/hooks/use-eligibility';
 
 import { EligibilityNudgeDialog } from './eligibility-nudge-dialog';
 import { useJobApply } from './use-job-apply';
@@ -32,6 +33,7 @@ interface ApplyButtonProps {
   jobId: string;
   jobTitle: string;
   organization: string | null;
+  classification: string | null;
   className?: string;
 }
 
@@ -41,9 +43,11 @@ export const ApplyButton = ({
   jobId,
   jobTitle,
   organization,
+  classification,
   className,
 }: ApplyButtonProps) => {
   const pathname = usePathname();
+  const { isExpert } = useEligibility();
   const {
     isAuthenticated,
     isAuthLoading,
@@ -64,10 +68,19 @@ export const ApplyButton = ({
   };
 
   const trackApply = (destination: string) => {
-    trackEvent(GA_EVENT.APPLY_BUTTON_CLICKED, {
-      job_id: jobId,
+    const userRole = !isAuthenticated
+      ? 'anonymous'
+      : isExpert
+        ? 'expert'
+        : 'user';
+
+    trackEvent(GA_EVENT.JOB_APPLY, {
+      event_category: 'job',
+      job_shortuuid: jobId,
+      job_classification: classification ?? '',
+      organization_name: organization ?? '',
+      user_role: userRole,
       job_title: jobTitle,
-      organization: organization ?? '',
       apply_destination: destination,
     });
   };

--- a/src/features/jobs/components/job-details/cta-card.tsx
+++ b/src/features/jobs/components/job-details/cta-card.tsx
@@ -14,6 +14,7 @@ interface CtaCardProps {
   jobId: string;
   jobTitle: string;
   organization: string | null;
+  classification: string | null;
 }
 
 export const CtaCard = ({
@@ -22,6 +23,7 @@ export const CtaCard = ({
   jobId,
   jobTitle,
   organization,
+  classification,
 }: CtaCardProps) => {
   if (!hasApplyUrl && !isExpertJob) return null;
 
@@ -35,6 +37,7 @@ export const CtaCard = ({
             jobId={jobId}
             jobTitle={jobTitle}
             organization={organization}
+            classification={classification}
             className='w-full'
           />
         </Suspense>

--- a/src/features/jobs/components/job-details/job-details-page.tsx
+++ b/src/features/jobs/components/job-details/job-details-page.tsx
@@ -51,6 +51,7 @@ export const JobDetailsPage = ({ job }: JobDetailsPageProps) => {
         jobId={job.id}
         jobTitle={job.title}
         organization={orgName}
+        classification={job.classification}
       />
     </>
   );

--- a/src/features/jobs/components/job-details/job-details-sidebar.tsx
+++ b/src/features/jobs/components/job-details/job-details-sidebar.tsx
@@ -25,6 +25,7 @@ export const JobDetailsSidebar = ({
         jobId={job.id}
         jobTitle={job.title}
         organization={organization?.name ?? null}
+        classification={job.classification}
       />
       {!hideOrgCard && organization && (
         <OrgInfoCard organization={organization} />

--- a/src/features/jobs/components/job-details/mobile-apply-bar.tsx
+++ b/src/features/jobs/components/job-details/mobile-apply-bar.tsx
@@ -14,6 +14,7 @@ interface MobileApplyBarProps {
   jobId: string;
   jobTitle: string;
   organization: string | null;
+  classification: string | null;
 }
 
 export const MobileApplyBar = ({
@@ -22,6 +23,7 @@ export const MobileApplyBar = ({
   jobId,
   jobTitle,
   organization,
+  classification,
 }: MobileApplyBarProps) => {
   if (!hasApplyUrl && !isExpertJob) return null;
 
@@ -35,6 +37,7 @@ export const MobileApplyBar = ({
             jobId={jobId}
             jobTitle={jobTitle}
             organization={organization}
+            classification={classification}
             className='w-full'
           />
         </Suspense>

--- a/src/features/jobs/schemas.ts
+++ b/src/features/jobs/schemas.ts
@@ -71,6 +71,7 @@ export const jobListItemSchema = z.object({
   title: nonEmptyStringSchema,
   href: nonEmptyStringSchema,
   hasApplyUrl: z.boolean(),
+  classification: nullableStringSchema,
   summary: nullableStringSchema,
   addresses: addressSchema.array().nullable(),
   infoTags: mappedInfoTagSchema.array(),

--- a/src/features/jobs/server/dtos/dto-to-job-list-item.ts
+++ b/src/features/jobs/server/dtos/dto-to-job-list-item.ts
@@ -88,6 +88,7 @@ export const dtoToJobListItem = (dto: JobListItemDto): JobListItemSchema => {
     title,
     href,
     hasApplyUrl: !!dto.url,
+    classification: dto.classification,
     summary: summary || getDefaultSummary(dto),
     addresses: addressLookup?.addresses ?? null,
     infoTags,

--- a/src/lib/analytics/constants.ts
+++ b/src/lib/analytics/constants.ts
@@ -12,8 +12,9 @@ export const GA_EVENT = {
   // Interest
   SIMILAR_JOB_CLICKED: 'similar_job_clicked',
 
-  // Conversion
-  APPLY_BUTTON_CLICKED: 'apply_button_clicked',
+  // Conversion. 'job_apply' is the historical event name from the previous
+  // frontend — GA4 key events and reports are keyed to it. Do not rename.
+  JOB_APPLY: 'job_apply',
 
   // Auth
   LOGIN_STARTED: 'login_started',
@@ -63,10 +64,15 @@ export type GaEventParams = {
     job_id: string;
     source: string;
   };
-  [GA_EVENT.APPLY_BUTTON_CLICKED]: {
-    job_id: string;
-    job_title: string;
-    organization: string;
+  // Parameter names match the previous frontend's payload so existing GA4
+  // custom dimensions keep working.
+  [GA_EVENT.JOB_APPLY]: {
+    event_category: 'job';
+    job_shortuuid: string;
+    job_classification: string;
+    organization_name: string;
+    user_role: string;
+    job_title?: string;
     apply_destination?: string;
   };
   [GA_EVENT.LOGIN_STARTED]: {

--- a/src/lib/analytics/track.ts
+++ b/src/lib/analytics/track.ts
@@ -5,5 +5,18 @@ export const trackEvent = <E extends keyof GaEventParams>(
   params: GaEventParams[E],
 ): void => {
   if (typeof window === 'undefined') return;
-  window.gtag?.('event', event, params);
+
+  // Never drop events fired before gtag.js loads: install the standard
+  // stub that queues into dataLayer — gtag.js replays the queue on load.
+  // (The previous `window.gtag?.()` silently discarded early clicks.)
+  if (!window.gtag) {
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = function gtag() {
+      // gtag.js requires the Arguments object itself, not an array
+      // eslint-disable-next-line prefer-rest-params
+      window.dataLayer?.push(arguments);
+    };
+  }
+
+  window.gtag('event', event, params);
 };

--- a/src/lib/analytics/types.d.ts
+++ b/src/lib/analytics/types.d.ts
@@ -1,3 +1,4 @@
 interface Window {
   gtag?: (...args: unknown[]) => void;
+  dataLayer?: unknown[];
 }


### PR DESCRIPTION
Apply-click tracking has been broken-in-practice since the new webapp deployed: the event *was* being sent, but under a new name (`apply_button_clicked`) with new parameter names — while the GA4 property's key events, reports, and custom dimensions are keyed to the previous frontend's `job_apply` contract (`event_category`/`job_shortuuid`/`job_classification`/`organization_name`/`user_role`). Result: months of apply clicks invisible in every report keyed to `job_apply`.

## Fixes
1. **Event contract restored** — `job_apply` with the exact legacy parameter shape (verified against `../app`'s `gaEvent(GA_EVENT_ACTION.JOB_APPLY, ...)`); `job_title`/`apply_destination` kept as extra params so the interim months' dimensions stay available
2. **`classification` added to the job schema** and threaded to the apply button (the DTO had it; the transform dropped it); `user_role` derived from session (`anonymous`/`user`/`expert`)
3. **Reliability regressions vs the old app fixed:**
   - GA scripts now load `afterInteractive` (old app's setting) instead of `lazyOnload` — job pages are SEO landing pages, and clicks before browser-idle raced the script
   - `trackEvent` installs the standard dataLayer-queueing gtag stub instead of `window.gtag?.()`, which silently discarded any event fired before gtag.js loaded
4. **Hardening**: GA measurement id shape-validated at build time (`/^G-[A-Z0-9]+$/`) since it's interpolated into an inline script

## Verification (wire-level, production build + real browser)
- Clicking Apply sends `POST /g/collect` with `en=job_apply&ep.event_category=job&ep.job_shortuuid=8oV21L&ep.job_classification=GROWTH&ep.organization_name=Morpho Labs&ep.user_role=anonymous&ep.apply_destination=login_redirect` → **204**
- Also verified the worst case: event fired immediately on load (racing gtag.js) still lands in the dataLayer and is delivered
- tsc clean, 132 tests green, build green

## Note for GA4
Data from the broken months exists in the property under `apply_button_clicked` — it's not lost, just misnamed; it can still be queried in Explorations for the gap period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2r9SoF8wmxr5FHzrmX1bi