### PR TITLE
fix(seo): exclude thin pillars from sitemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "2.35.5",
+  "version": "2.35.6",
   "private": true,
   "packageManager": "pnpm@10.28.0",
   "scripts": {

--- a/src/lib/server/sitemap/chunks.test.ts
+++ b/src/lib/server/sitemap/chunks.test.ts
@@ -3,9 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getJobsChunk, getPillarsChunk } from './chunks';
 import {
   JOBS_CHUNK_COUNT,
-  JOBS_CHUNK_SIZE,
   PILLAR_CHUNK_COUNT,
-  PILLAR_CHUNK_SIZE,
   SITEMAP_INDEX_PATHS,
 } from './constants';
 
@@ -52,52 +50,45 @@ describe('sitemap index paths', () => {
 });
 
 describe('getJobsChunk', () => {
-  it('slices 1-based chunks of the configured size', async () => {
-    mockFetchSitemapJobs.mockResolvedValue(makeJobs(JOBS_CHUNK_SIZE + 2));
+  it('balances the complete inventory across the advertised chunks', async () => {
+    mockFetchSitemapJobs.mockResolvedValue(makeJobs(7));
 
     const first = await getJobsChunk(1);
     const second = await getJobsChunk(2);
 
-    expect(first).toHaveLength(JOBS_CHUNK_SIZE);
-    expect(second).toHaveLength(2);
-    expect(second[0].loc).toContain(`/job-${JOBS_CHUNK_SIZE}/`);
+    expect(first).toHaveLength(3);
+    expect(second).toHaveLength(4);
+    expect([...first, ...second].map((item) => item.loc)).toEqual(
+      makeJobs(7).map((item) => expect.stringContaining(item.href)),
+    );
   });
 
   it('returns an empty chunk when out of range', async () => {
     mockFetchSitemapJobs.mockResolvedValue(makeJobs(3));
     await expect(getJobsChunk(99)).resolves.toEqual([]);
   });
-
-  it('keeps later growth in the final advertised chunk', async () => {
-    mockFetchSitemapJobs.mockResolvedValue(
-      makeJobs(JOBS_CHUNK_SIZE * JOBS_CHUNK_COUNT + 2),
-    );
-
-    const final = await getJobsChunk(JOBS_CHUNK_COUNT);
-
-    expect(final).toHaveLength(JOBS_CHUNK_SIZE + 2);
-    expect(final[0].loc).toContain(`/job-${JOBS_CHUNK_SIZE}/`);
-  });
 });
 
 describe('getPillarsChunk', () => {
   it('prefixes slugs with the frontend url and parses lastModified', async () => {
-    mockFetchPillarSitemapSlugs.mockResolvedValue(makeSlugs(2));
+    mockFetchPillarSitemapSlugs.mockResolvedValue(makeSlugs(9));
 
     const chunk = await getPillarsChunk(1);
 
-    expect(chunk).toHaveLength(2);
+    expect(chunk).toHaveLength(3);
     expect(chunk[0].loc).toMatch(/\/t-tag-0$/);
     expect(chunk[0].lastModified).toBeInstanceOf(Date);
   });
 
-  it('keeps later growth in the final advertised chunk', async () => {
-    mockFetchPillarSitemapSlugs.mockResolvedValue(
-      makeSlugs(PILLAR_CHUNK_SIZE * PILLAR_CHUNK_COUNT + 1),
+  it('keeps every advertised chunk populated after the inventory shrinks', async () => {
+    mockFetchPillarSitemapSlugs.mockResolvedValue(makeSlugs(4_773));
+
+    const chunks = await Promise.all(
+      Array.from({ length: PILLAR_CHUNK_COUNT }, (_, index) =>
+        getPillarsChunk(index + 1),
+      ),
     );
 
-    const final = await getPillarsChunk(PILLAR_CHUNK_COUNT);
-
-    expect(final).toHaveLength(PILLAR_CHUNK_SIZE + 1);
+    expect(chunks.map((chunk) => chunk.length)).toEqual([1591, 1591, 1591]);
   });
 });

--- a/src/lib/server/sitemap/chunks.ts
+++ b/src/lib/server/sitemap/chunks.ts
@@ -5,25 +5,22 @@ import { fetchPillarSitemapSlugs } from '@/features/pillar/server/data';
 import { clientEnv } from '@/lib/env/client';
 
 import type { SitemapEntry } from './build-sitemap-xml';
-import {
-  JOBS_CHUNK_COUNT,
-  JOBS_CHUNK_SIZE,
-  PILLAR_CHUNK_COUNT,
-  PILLAR_CHUNK_SIZE,
-} from './constants';
+import { JOBS_CHUNK_COUNT, PILLAR_CHUNK_COUNT } from './constants';
 
 const FRONTEND_URL = clientEnv.FRONTEND_URL;
 
 const sliceChunk = <T>(
   items: T[],
   chunk1Based: number,
-  size: number,
   totalChunks: number,
 ): T[] => {
   if (chunk1Based < 1 || chunk1Based > totalChunks) return [];
 
-  const start = (chunk1Based - 1) * size;
-  const end = chunk1Based === totalChunks ? undefined : start + size;
+  // Balance the current inventory across every advertised file. Eligibility
+  // changes can shrink the sitemap substantially; fixed-size slicing would
+  // leave the final files empty and create a new Search Console error.
+  const start = Math.floor(((chunk1Based - 1) * items.length) / totalChunks);
+  const end = Math.floor((chunk1Based * items.length) / totalChunks);
   return items.slice(start, end);
 };
 
@@ -31,7 +28,7 @@ export const getJobsChunk = async (
   chunk1Based: number,
 ): Promise<SitemapEntry[]> => {
   const jobs = await fetchSitemapJobs();
-  return sliceChunk(jobs, chunk1Based, JOBS_CHUNK_SIZE, JOBS_CHUNK_COUNT).map(
+  return sliceChunk(jobs, chunk1Based, JOBS_CHUNK_COUNT).map(
     ({ href, lastModified }) => ({
       loc: `${FRONTEND_URL}${href}`,
       lastModified,
@@ -43,13 +40,10 @@ export const getPillarsChunk = async (
   chunk1Based: number,
 ): Promise<SitemapEntry[]> => {
   const slugs = await fetchPillarSitemapSlugs();
-  return sliceChunk(
-    slugs,
-    chunk1Based,
-    PILLAR_CHUNK_SIZE,
-    PILLAR_CHUNK_COUNT,
-  ).map(({ slug, lastModified }) => ({
-    loc: `${FRONTEND_URL}/${slug}`,
-    lastModified: new Date(lastModified),
-  }));
+  return sliceChunk(slugs, chunk1Based, PILLAR_CHUNK_COUNT).map(
+    ({ slug, lastModified }) => ({
+      loc: `${FRONTEND_URL}/${slug}`,
+      lastModified: new Date(lastModified),
+    }),
+  );
 };

--- a/src/lib/server/sitemap/constants.ts
+++ b/src/lib/server/sitemap/constants.ts
@@ -1,10 +1,7 @@
 import 'server-only';
 
-// Keep the number of root-level child sitemap URLs stable. The final chunk for
-// each kind absorbs growth so /sitemap.xml never needs a middleware request in
-// order to decide which files exist.
-export const JOBS_CHUNK_SIZE = 5000;
-export const PILLAR_CHUNK_SIZE = 3000;
+// Keep the number of root-level child sitemap URLs stable so /sitemap.xml
+// never needs a middleware request in order to decide which files exist.
 export const JOBS_CHUNK_COUNT = 2;
 export const PILLAR_CHUNK_COUNT = 3;
 


### PR DESCRIPTION
## Summary
- balance current sitemap inventories across the fixed advertised child sitemap files
- prevent the reduced eligible pillar set from leaving an advertised sitemap empty
- bump webapp patch version to 2.35.6

## Context
Search Console reported sitemap URLs excluded by noindex. The page noindex rule is intentional for pillar pages with fewer than three current jobs; the sitemap inventory was stale because middleware counted historical jobs.

## Coordination
Merge and deploy jobstash/middleware#181 first, then deploy this PR so regenerated child sitemaps consume the corrected inventory.

## Validation
- 145 Vitest tests pass
- TypeScript passes
- production Next.js build passes
- focused Oxlint passes