### PR TITLE
chore(seo): rebuild sitemaps after middleware fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "2.35.6",
+  "version": "2.35.7",
   "private": true,
   "packageManager": "pnpm@10.28.0",
   "scripts": {


### PR DESCRIPTION
## Summary
- release webapp 2.35.7 after the coordinated middleware eligibility fixes
- regenerate job sitemap chunks from the corrected 5,286-job inventory
- clear cached pillar 404 responses created before normalized facet resolution deployed

## Validation
- production Next.js build passes
- 145 Vitest tests pass
- TypeScript passes
- pre-push lint completes with only the four existing repository warnings