### PR TITLE
feat(home): feature fully remote and regional pillars

### DIFF
--- a/src/components/hero-ctas.test.tsx
+++ b/src/components/hero-ctas.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import type { ReactNode } from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { HeroCtas } from './hero-ctas';
+
+afterEach(() => {
+  cleanup();
+});
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: ReactNode;
+    href: string;
+  }) => (
+    // eslint-disable-next-line @next/next/no-html-link-for-pages
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/lib/analytics', () => ({
+  GA_EVENT: { HERO_CTA_CLICKED: 'hero_cta_clicked' },
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/primary-cta', () => ({
+  PrimaryCTA: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/hero-jobs-for-you-button.lazy', () => ({
+  HeroJobsForYouButton: () => <button>Jobs for You</button>,
+}));
+
+describe('HeroCtas', () => {
+  it('links the homepage directly to the fully remote jobs pillar', () => {
+    render(<HeroCtas />);
+
+    expect(
+      screen.getByRole('link', { name: 'Fully Remote Jobs' }),
+    ).toHaveAttribute('href', '/lt-fully-remote');
+    expect(
+      screen.getByRole('button', { name: 'Jobs for You' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/hero-ctas.tsx
+++ b/src/components/hero-ctas.tsx
@@ -26,6 +26,12 @@ const CRYPTO_BEGINNER_JOBS: PillarLink = {
   gaSource: 'crypto_beginner_jobs',
 };
 
+const FULLY_REMOTE_JOBS: PillarLink = {
+  slug: 'lt-fully-remote',
+  label: 'Fully Remote Jobs',
+  gaSource: 'fully_remote_jobs',
+};
+
 const SECONDARY_CLASS = 'bg-input/30 text-base';
 
 const PrimaryPillarButton = ({ pillar }: { pillar: PillarLink }) => (
@@ -93,10 +99,11 @@ export const HeroCtas = ({ slug }: Props) => {
   }
 
   return (
-    <div className='flex flex-col items-center gap-3 sm:flex-row'>
+    <div className='flex flex-col flex-wrap items-center justify-center gap-3 sm:flex-row'>
       <PrimaryPillarButton pillar={URGENTLY_HIRING} />
       <SecondaryPillarButton pillar={CRYPTO_BEGINNER_JOBS} />
       <HeroJobsForYouButton />
+      <SecondaryPillarButton pillar={FULLY_REMOTE_JOBS} />
     </div>
   );
 };

--- a/src/features/home/components/pillar-items/pillar-items.test.tsx
+++ b/src/features/home/components/pillar-items/pillar-items.test.tsx
@@ -65,6 +65,37 @@ describe('fetchPillarItems', () => {
     expect(categories).toContain('locationType');
     expect(categories).toContain('commitment');
   });
+
+  it('includes the fully remote pillar and canonical main regions', async () => {
+    const items = await fetchPillarItems();
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        {
+          category: 'locationType',
+          label: 'Fully Remote',
+          href: '/lt-fully-remote',
+        },
+        { category: 'location', label: 'Europe', href: '/l-europe' },
+        {
+          category: 'location',
+          label: 'North America',
+          href: '/l-north-america',
+        },
+        {
+          category: 'location',
+          label: 'Latin America',
+          href: '/l-latin-america',
+        },
+        {
+          category: 'location',
+          label: 'Asia-Pacific',
+          href: '/l-asia-pacific',
+        },
+        { category: 'location', label: 'Africa', href: '/l-africa' },
+      ]),
+    );
+  });
 });
 
 describe('HeroWithPillars', () => {

--- a/src/features/home/server/data.ts
+++ b/src/features/home/server/data.ts
@@ -30,9 +30,31 @@ export const fetchPillarItems = async (): Promise<PillarItem[]> => {
     { category: 'location', label: 'London', href: '/l-london' },
     { category: 'location', label: 'New York', href: '/l-new-york' },
     { category: 'location', label: 'Singapore', href: '/l-singapore' },
+    { category: 'location', label: 'Europe', href: '/l-europe' },
+    {
+      category: 'location',
+      label: 'North America',
+      href: '/l-north-america',
+    },
+    {
+      category: 'location',
+      label: 'Latin America',
+      href: '/l-latin-america',
+    },
+    {
+      category: 'location',
+      label: 'Asia-Pacific',
+      href: '/l-asia-pacific',
+    },
+    { category: 'location', label: 'Africa', href: '/l-africa' },
 
     // Location Type - Work arrangement
     { category: 'locationType', label: 'Remote', href: '/lt-remote' },
+    {
+      category: 'locationType',
+      label: 'Fully Remote',
+      href: '/lt-fully-remote',
+    },
     { category: 'locationType', label: 'Onsite', href: '/lt-onsite' },
     { category: 'locationType', label: 'Hybrid', href: '/lt-hybrid' },
 


### PR DESCRIPTION
## Summary
- add Fully Remote Jobs to the main homepage CTA row
- add Fully Remote to the smaller homepage pillar links
- add canonical Europe, North America, Latin America, Asia-Pacific, and Africa pillar links

## Verification
- canonical fully remote and regional pillar URLs resolve in production
- all 286 webapp tests pass
- TypeScript passes
- production Next.js build passes